### PR TITLE
Map page support for query parameters

### DIFF
--- a/src/map/index.tsx
+++ b/src/map/index.tsx
@@ -44,7 +44,25 @@ function MapPage() {
                     const lat = parseFloat(searchParams.get("lat") || "33.78010647946605");
                     const lon = parseFloat(searchParams.get("lon") || "-84.38955018824828");
                     setCenter([lat, lon]);
-                    setLocationInput(`(${lat}, ${lon})`);
+
+                    Geocode.setApiKey(GOOGLE_GEOCODING_API_KEY);
+                    Geocode.fromLatLng(lat.toString(), lon.toString()).then(
+                        (response) => {
+                            if (response.results && response.results.length > 0 && response.results[0].formatted_address) {
+                                setLocationInput(`${response.results[0].formatted_address}`);
+                            } else {
+                                setLocationInput(`(${lat}, ${lon})`);
+                            }
+                        },
+                        (error) => {
+                            setLoading(false);
+                            if ((error?.message || '').includes('ZERO_RESULTS') || (error?.message || '').includes('Provided address is invalid')) {
+                                setIsUnknownLocation(true);
+                            } else {
+                                console.error(error);
+                            }
+                        }
+                    );
                 }
             } catch (e) {
                 console.error("Unable to parse latitude and longitude query parameters");

--- a/src/map/index.tsx
+++ b/src/map/index.tsx
@@ -41,10 +41,12 @@ function MapPage() {
                 const searchParams = new URLSearchParams(search);
                 const validSearchParams = searchParams.get("lat") && searchParams.get("lon");
                 if (validSearchParams) {
+                    // set latitude and longitude of marker
                     const lat = parseFloat(searchParams.get("lat") || "33.78010647946605");
                     const lon = parseFloat(searchParams.get("lon") || "-84.38955018824828");
                     setCenter([lat, lon]);
 
+                    // set search text of place (query Google Geo Decoding API to get the address of a place from latitude and longitude values)
                     Geocode.setApiKey(GOOGLE_GEOCODING_API_KEY);
                     Geocode.fromLatLng(lat.toString(), lon.toString()).then(
                         (response) => {

--- a/src/map/index.tsx
+++ b/src/map/index.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import Navbar from '../navbar';
 import styles from './styles.module.css';
 import {getAuth} from 'firebase/auth';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import {setupAuthListener} from '../authredirect/setup-auth-listener';
 import firebaseApp from '../firebase';
 import {checkedIfAllowedOnPage, k_admin_role, k_regular_user_role} from '../authredirect/auth-check';
@@ -23,6 +23,7 @@ function MapPage() {
     const auth = getAuth(firebaseApp);
     const db = getFirestore(firebaseApp);
     const navigate = useNavigate();
+    const { search } = useLocation();
     const [center, setCenter] = useState<any>([33.78010647946605, -84.38955018824828]);
     const [zoom, setZoom] = useState<number>(16.0);
     const [radius, setRadius] = useState<number>(444);
@@ -107,6 +108,18 @@ function MapPage() {
             }
         });
     }, [auth]);
+
+    // use query parameter to set the center location of the map (if they are defined)
+    useEffect(() => {
+        try {
+            const searchParams = new URLSearchParams(search);
+            const lat = parseFloat(searchParams.get("lat") || "33.78010647946605");
+            const lon = parseFloat(searchParams.get("lon") || "-84.38955018824828");
+            setCenter([lat, lon]);
+        } catch (e) {
+            console.error("Unable to parse latitude and longitude query parameters");
+        }
+    }, [search]);
 
     // rate limit the frequency at which we query search input
     const debouncedSearchInput = useDebouncedCallback(

--- a/src/map/index.tsx
+++ b/src/map/index.tsx
@@ -33,6 +33,18 @@ function MapPage() {
     const [locationInput, setLocationInput] = useState<string>('930 Spring St NW, Atlanta, GA 30309');
     const [isUnknownLocation, setIsUnknownLocation] = useState<boolean>(false);
 
+    // use query parameter to set the center location of the map (if they are defined)
+    const setLocationFromQueryParams = () => {
+        try {
+            const searchParams = new URLSearchParams(search);
+            const lat = parseFloat(searchParams.get("lat") || "33.78010647946605");
+            const lon = parseFloat(searchParams.get("lon") || "-84.38955018824828");
+            setCenter([lat, lon]);
+        } catch (e) {
+            console.error("Unable to parse latitude and longitude query parameters");
+        }
+    }
+
     const queryLocations = async () => {
         // setFacilities([]);
         if (db) {
@@ -87,14 +99,16 @@ function MapPage() {
     useEffect(() => {
         checkedIfAllowedOnPage(auth, navigate, [k_regular_user_role, k_admin_role]);
         setupAuthListener(auth, navigate, true, false);
-    }, [auth, navigate]);
+        setLocationFromQueryParams();
+    }, [auth, navigate, setLocationFromQueryParams]);
 
     // request for new list of facilities nearby location
     useEffect(() => {
         // search facilities when center or radius is updated
         setLoading(true);
         debounced(radius);
-    }, [center, radius, debounced]);
+        setLocationFromQueryParams();
+    }, [center, radius, debounced, setLocationFromQueryParams]);
 
     // check if admin (to allow them to delete facilities)
     useEffect(() => {
@@ -108,18 +122,6 @@ function MapPage() {
             }
         });
     }, [auth]);
-
-    // use query parameter to set the center location of the map (if they are defined)
-    useEffect(() => {
-        try {
-            const searchParams = new URLSearchParams(search);
-            const lat = parseFloat(searchParams.get("lat") || "33.78010647946605");
-            const lon = parseFloat(searchParams.get("lon") || "-84.38955018824828");
-            setCenter([lat, lon]);
-        } catch (e) {
-            console.error("Unable to parse latitude and longitude query parameters");
-        }
-    }, [search]);
 
     // rate limit the frequency at which we query search input
     const debouncedSearchInput = useDebouncedCallback(


### PR DESCRIPTION
Map page supports starting at a location defined by query parameter values. Try this page as an example: [http://localhost:3000/facility-map?lat=37.32130693942074&lon=-122.06610526063467](http://localhost:3000/facility-map?lat=37.32130693942074&lon=-122.06610526063467)

This will help with [J2TCM-17](https://jib-2310-team-code-monkeys.atlassian.net/browse/J2TCM-17) when it is implemented.

[J2TCM-17]: https://jib-2310-team-code-monkeys.atlassian.net/browse/J2TCM-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ